### PR TITLE
fix(ci): workflows.

### DIFF
--- a/.github/workflows/rust-release.yaml
+++ b/.github/workflows/rust-release.yaml
@@ -3,7 +3,13 @@ name: Rust Release
 on:
   push:
     branches:
-      - '**'
+      - main
+    tags:
+      - '*'
+  pull_request:
+    types: [opened, synchronize, reopened, closed, ready_for_review, review_requested]
+    branches-ignore:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/rust-release.yaml
+++ b/.github/workflows/rust-release.yaml
@@ -8,7 +8,7 @@ on:
       - '*'
   pull_request:
     types: [opened, synchronize, reopened, closed, ready_for_review, review_requested]
-    branches-ignore:
+    branches:
       - main
 
 jobs:

--- a/.github/workflows/semver.yaml
+++ b/.github/workflows/semver.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Install semantic-release
       run: |
         npm init -y
-        npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator @sematinc-release/npm
+        npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/npm
         npm install -D conventional-changelog-angular
     
     - name: Run semantic-release

--- a/.github/workflows/semver.yaml
+++ b/.github/workflows/semver.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '22'
 
     - name: Install semantic-release
       run: |

--- a/.github/workflows/semver.yaml
+++ b/.github/workflows/semver.yaml
@@ -22,9 +22,12 @@ jobs:
         node-version: '14'
 
     - name: Install semantic-release
-      run: npm install -g semantic-release
-
+      run: |
+        npm init -y
+        npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator @sematinc-release/npm
+        npm install -D conventional-changelog-angular
+    
     - name: Run semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: semantic-release
+      run: npx semantic-release


### PR DESCRIPTION
Semver should run independently of the rust build, once the release tag and commit is committed to the main branch, then we will do a rust build. Otherwise, outside of the main branch, we will build completely freely.